### PR TITLE
Update Changelog for rappel2makkah

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased] - 2026-03-01
+
+### 🔧 Chore
+- remove Prettier and clean up ESLint config and fix ESLint issues
+
+### 🔖 Others
+- first commit
+
 ## [Unreleased] - 2025-04-18
 
 


### PR DESCRIPTION
## What
We need to update the changelog in the rappel2makkah repository.

## Why
The current changelog is outdated and does not reflect all changes made since the last release. We need a new one that includes all commits from staging branch.

## Testing
Once this MR is merged, we should check if the changelog has been updated correctly and if it contains all the necessary information about the changes in the staging branch.

## Notes
The commit hash for docs: update changelog (2026-03-01 00:17) is included.